### PR TITLE
QUANTTYPE should be parsed via BigDecimal

### DIFF
--- a/lib/qbxml/types.rb
+++ b/lib/qbxml/types.rb
@@ -11,6 +11,7 @@ module Qbxml::Types
   TIME_CAST  = Proc.new {|d| d ? Time.parse(d).xmlschema : Time.now.xmlschema }
   INT_CAST   = Proc.new {|d| d ? Integer(d.to_i) : 0 }
   STR_CAST   = Proc.new {|d| d ? String(d) : ''}
+  BIGDECIMAL_CAST   = Proc.new {|d| d ? BigDecimal.new(d) : 0.0}
 
   TYPE_MAP= {
     "AMTTYPE"          => FLOAT_CAST,
@@ -24,7 +25,7 @@ module Qbxml::Types
     "INTTYPE"          => INT_CAST,
     "PERCENTTYPE"      => FLOAT_CAST,
     "PRICETYPE"        => FLOAT_CAST,
-    "QUANTYPE"         => INT_CAST,
+    "QUANTYPE"         => BIGDECIMAL_CAST,
     "STRTYPE"          => STR_CAST,
     "TIMEINTERVALTYPE" => STR_CAST
   }


### PR DESCRIPTION
QB allows any number-like value in the Quantity On Hand field for an Item, not just integers. Thus we need to preserve any precision.
