### PR TITLE
Fix error on float cast when the string to parse has a ',' in it.

### DIFF
--- a/lib/qbxml/types.rb
+++ b/lib/qbxml/types.rb
@@ -5,7 +5,10 @@ module Qbxml::Types
     :qbpos => :qbposxml
   }.freeze
 
-  FLOAT_CAST = Proc.new {|d| d ? Float(d) : 0.0}
+  FLOAT_CAST = Proc.new do |d|
+    return 0.0 unless d
+    Float(d.is_a?(String) ? d.gsub(/,/, ".") : d)
+  end
   BOOL_CAST  = Proc.new {|d| d ? (d.to_s.downcase == 'true' ? true : false) : false }
   DATE_CAST  = Proc.new {|d| d ? Date.parse(d).strftime("%Y-%m-%d") : Date.today.strftime("%Y-%m-%d") }
   TIME_CAST  = Proc.new {|d| d ? Time.parse(d).xmlschema : Time.now.xmlschema }


### PR DESCRIPTION
I needed this change because QB was sending a float string with "0,0" rather than "0.0" after using VendorAdd, so when doing Float("0,0") it throws an exception.
Let me know if I should add an example or something so you can check your self.
