### PR TITLE
Handle parsing of % character in a float type

### DIFF
--- a/lib/qbxml/types.rb
+++ b/lib/qbxml/types.rb
@@ -5,7 +5,7 @@ module Qbxml::Types
     :qbpos => :qbposxml
   }.freeze
 
-  FLOAT_CAST = Proc.new {|d| d ? Float(d) : 0.0}
+  FLOAT_CAST = Proc.new {|d| d ? d.to_f : 0.0}
   BOOL_CAST  = Proc.new {|d| d ? (d.to_s.downcase == 'true' ? true : false) : false }
   DATE_CAST  = Proc.new {|d| d ? Date.parse(d).strftime("%Y-%m-%d") : Date.today.strftime("%Y-%m-%d") }
   TIME_CAST  = Proc.new {|d| d ? Time.parse(d).xmlschema : Time.now.xmlschema }

--- a/test/unit/xml_to_hash_test.rb
+++ b/test/unit/xml_to_hash_test.rb
@@ -26,5 +26,80 @@ class XmlToHashTest < Minitest::Test
     assert_equal h, qbxml.from_qbxml("<?qbxml version=\"7.0\"?>\n<QBXML>\n  <QBXMLMsgsRq>\n    <InvoiceQueryRq>\n      <IncludeRetElement>TxnID</IncludeRetElement>\n    <IncludeRetElement>RefNumber</IncludeRetElement>\n    </InvoiceQueryRq>\n  </QBXMLMsgsRq>\n</QBXML>\n")
   end
 
-end
+  def test_float_percentage
+    qbxml = Qbxml.new
 
+    h = {
+      "qbxml" => {
+        "xml_attributes" => {},
+        "qbxml_msgs_rs" => {
+          "xml_attributes" => {},
+          "item_query_rs" => {
+            "xml_attributes" => {
+              "requestID" => "Retrieve items",
+              "statusCode" => "0",
+              "statusSeverity" => "Info",
+              "statusMessage" => "Status OK",
+              "iteratorRemainingCount" => "0",
+              "iteratorID" => "{10c05cbd-b25b-4a85-8aa0-8bce89e6e900}"
+            },
+            "item_service_ret" => {
+              "xml_attributes" => {},
+              "list_id" => "80000005-1468535148",
+              "time_created" => "2016-07-14T15:25:48-08:00",
+              "time_modified" => "2016-07-14T15:25:48-08:00",
+              "edit_sequence" => "1468535148",
+              "name" => "let's get intuit",
+              "full_name" => "let's get intuit",
+              "is_active" => true,
+              "sublevel" => 0,
+              "sales_or_purchase" => {
+                "xml_attributes" => {},
+                "price_percent" => 18.0,
+                "account_ref" => {
+                  "xml_attributes" => {},
+                  "list_id" => "80000015-1457547358",
+                  "full_name" => "Repairs and Maintenance"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    xml = <<-XML
+      <QBXML>
+        <QBXMLMsgsRs>
+          <ItemQueryRs requestID="Retrieve items"
+                       statusCode="0"
+                       statusSeverity="Info"
+                       statusMessage="Status OK"
+                       iteratorRemainingCount="0"
+                       iteratorID="{10c05cbd-b25b-4a85-8aa0-8bce89e6e900}">
+            <ItemServiceRet>
+              <ListID>80000005-1468535148</ListID>
+              <TimeCreated>2016-07-14T15:25:48-08:00</TimeCreated>
+              <TimeModified>2016-07-14T15:25:48-08:00</TimeModified>
+              <EditSequence>1468535148</EditSequence>
+              <Name>let's get intuit</Name>
+              <FullName>let's get intuit</FullName>
+              <IsActive>true</IsActive>
+              <Sublevel>0</Sublevel>
+              <SalesOrPurchase>
+                <PricePercent>18.0%</PricePercent>
+                <AccountRef>
+                  <ListID>80000015-1457547358</ListID>
+                  <FullName>Repairs and Maintenance</FullName>
+                </AccountRef>
+              </SalesOrPurchase>
+            </ItemServiceRet>
+          </ItemQueryRs>
+        </QBXMLMsgsRs>
+      </QBXML>
+    XML
+
+    assert_equal h, qbxml.from_qbxml(xml)
+  end
+
+end


### PR DESCRIPTION
We've encountered a couple cases where a customer's Item query can come back with a string containing an actual `%` character in a percentage field, which is specified as a float type.

Passing a value of `"18.0%"` to `Float()` blows up with a (technically very correct) exception of `ArgumentError: invalid value for Float(): "18.0%"`.  

Using `"18.0%".to_f` instead simply stops parsing when it encounters a non-valid character, and returns `18.0`.