### PR TITLE
Eliminate Ruby 2.6 BigDecimal warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ rvm:
   - 2.1
   - 2.2
   - 2.3.1
+  - 2.4
+  - 2.5
+  - 2.6
 
 gemfile:
   - gemfiles/rails_5.0.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,19 @@ matrix:
   exclude:
     - rvm: 2.1
       gemfile: gemfiles/rails_5.0.gemfile
+    - rvm: 2.4
+      gemfile: gemfiles/rails_4.2.gemfile
+    - rvm: 2.4
+      gemfile: gemfiles/rails_4.1.gemfile
+    - rvm: 2.5
+      gemfile: gemfiles/rails_4.2.gemfile
+    - rvm: 2.5
+      gemfile: gemfiles/rails_4.1.gemfile
+    - rvm: 2.6
+      gemfile: gemfiles/rails_4.2.gemfile
+    - rvm: 2.6
+      gemfile: gemfiles/rails_4.1.gemfile
 
 before_install:
   - if ruby --version | cut -d ' ' -f 2 | grep -q 2.1.5p273 ; then gem update --system 2.4.8; fi
+  - if ruby --version | cut -d ' ' -f 2 | grep -q 2.5.5p157 ; then gem install bundler:1.15.0; fi

--- a/lib/qbxml/types.rb
+++ b/lib/qbxml/types.rb
@@ -11,7 +11,12 @@ module Qbxml::Types
   TIME_CAST  = Proc.new {|d| d ? Time.parse(d).xmlschema : Time.now.xmlschema }
   INT_CAST   = Proc.new {|d| d ? Integer(d.to_i) : 0 }
   STR_CAST   = Proc.new {|d| d ? String(d) : ''}
-  BIGDECIMAL_CAST   = Proc.new {|d| d ? BigDecimal.new(d) : 0.0}
+
+  if Gem::Version.new(RUBY_VERSION.dup) <= Gem::Version.new('2.1')
+    BIGDECIMAL_CAST = Proc.new {|d| d ? BigDecimal(d).to_f : 0.0}
+  else
+    BIGDECIMAL_CAST = Proc.new {|d| d ? BigDecimal(d) : 0.0}
+  end
 
   TYPE_MAP= {
     "AMTTYPE"          => FLOAT_CAST,

--- a/test/unit/xml_to_hash_test.rb
+++ b/test/unit/xml_to_hash_test.rb
@@ -121,4 +121,163 @@ class XmlToHashTest < Minitest::Test
     assert_equal h, qbxml.from_qbxml(xml)
   end
 
+  def test_bigdecimal
+    injected_time = Time.now.strftime("%Y-%m-%dT%H:%M:%S%:z")
+
+    qbxml = Qbxml.new
+    h = {
+      "qbxml" => {
+        "xml_attributes" => {},
+        "qbxml_msgs_rs"=> {
+          "xml_attributes" => {},
+          "sales_receipt_add_rs" => {
+            "xml_attributes" => {
+              "statusCode" => "0",
+              "statusSeverity" => "Info",
+              "statusMessage" => "Status OK"
+            },
+            "sales_receipt_ret" => {
+              "xml_attributes" => {},
+              "txn_id" => "1C0-1433857054",
+              "time_created" => injected_time,
+              "time_modified" => injected_time,
+              "edit_sequence" => "1433850554",
+              "txn_number" => 89,
+              "customer_ref" => {
+                "xml_attributes" => {},
+                "list_id" => "80000013-1433852150",
+                "full_name" => "custfullname"
+              },
+              "template_ref" => {
+                "xml_attributes" => {},
+                "list_id" => "80000009-1433199758",
+                "full_name" => "Custom Sales Receipt"
+              },
+              "txn_date" => "2019-06-09",
+              "ref_number" => "1040000529",
+              "is_pending" => false,
+              "payment_method_ref" => {
+                "xml_attributes" => {},
+                "list_id" => "8000000A-1433718272",
+                "full_name" => "paymentmethod"
+              },
+              "due_date" => "2019-06-09",
+              "ship_date" => "2019-06-09",
+             "subtotal" => 0.2,
+              "item_sales_tax_ref" => {
+                "xml_attributes" => {},
+                "list_id" => "80000009-1433719484",
+                "full_name" => "Tax agency"
+              },
+              "sales_tax_percentage" => 8.25,
+              "sales_tax_total" => 0.02,
+              "total_amount" => 0.22,
+              "is_to_be_printed" => true,
+              "is_to_be_emailed" => false,
+              "customer_sales_tax_code_ref" => {
+                "xml_attributes" => {},
+                "list_id" => "80000002-1403304324",
+                "full_name" => "Non"
+              },
+              "deposit_to_account_ref" => {
+                "xml_attributes" => {},
+                "list_id" => "8000003D-1433719666",
+                "full_name" => "Undeposited Funds"
+              },
+              "sales_receipt_line_ret" => {
+                "xml_attributes" => {},
+                "txn_line_id" => "1C2-1433632154",
+                "item_ref" => {
+                  "xml_attributes" => {},
+                  "list_id" => "8000001F-1433854453",
+                  "full_name" => "ABCD0000"
+                },
+                "desc" => "description",
+                "quantity" => 0.2,
+                "rate" => 1.0,
+                "amount" => 0.2,
+                "service_date" => "2019-06-09",
+                "sales_tax_code_ref"=> {
+                  "xml_attributes" => {},
+                  "list_id" => "80000001-1403304324",
+                  "full_name"=>"Tax"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    xml = <<-XML
+      <QBXML>
+        <QBXMLMsgsRs>
+          <SalesReceiptAddRs statusCode="0" statusSeverity="Info" statusMessage="Status OK">
+              <SalesReceiptRet>
+                <TxnID>1C0-1433857054</TxnID>
+                <TimeCreated>#{injected_time}</TimeCreated>
+                <TimeModified>#{injected_time}</TimeModified>
+                <EditSequence>1433850554</EditSequence>
+                <TxnNumber>89</TxnNumber>
+                <CustomerRef>
+                  <ListID>80000013-1433852150</ListID>
+                  <FullName>custfullname</FullName>
+                </CustomerRef>
+                <TemplateRef>
+                  <ListID>80000009-1433199758</ListID>
+                  <FullName>Custom Sales Receipt</FullName>
+                </TemplateRef>
+                <TxnDate>2019-06-09</TxnDate>
+                <RefNumber>1040000529</RefNumber>
+                <IsPending>false</IsPending>
+                <PaymentMethodRef>
+                  <ListID>8000000A-1433718272</ListID>
+                  <FullName>paymentmethod</FullName>
+                </PaymentMethodRef>
+                <DueDate>2019-06-09</DueDate>
+                <ShipDate>2019-06-09</ShipDate>
+                <Subtotal>0.20</Subtotal>
+                <ItemSalesTaxRef>
+                  <ListID>80000009-1433719484</ListID>
+                  <FullName>Tax agency</FullName>
+                </ItemSalesTaxRef>
+                <SalesTaxPercentage>8.25</SalesTaxPercentage>
+                <SalesTaxTotal>0.02</SalesTaxTotal>
+                <TotalAmount>0.22</TotalAmount>
+                <IsToBePrinted>true</IsToBePrinted>
+                <IsToBeEmailed>false</IsToBeEmailed>
+                <CustomerSalesTaxCodeRef>
+                  <ListID>80000002-1403304324</ListID>
+                  <FullName>Non</FullName>
+                </CustomerSalesTaxCodeRef>
+                <DepositToAccountRef>
+                  <ListID>8000003D-1433719666</ListID>
+                  <FullName>Undeposited Funds</FullName>
+                </DepositToAccountRef>
+                <SalesReceiptLineRet>
+                  <TxnLineID>1C2-1433632154</TxnLineID>
+                  <ItemRef>
+                    <ListID>8000001F-1433854453</ListID>
+                    <FullName>ABCD0000</FullName>
+                  </ItemRef>
+                  <Desc>description</Desc>
+                  <Quantity>0.2</Quantity>
+                  <Rate>1.00</Rate>
+                  <Amount>0.20</Amount>
+                  <ServiceDate>2019-06-09</ServiceDate>
+                  <SalesTaxCodeRef>
+                    <ListID>80000001-1403304324</ListID>
+                    <FullName>Tax</FullName>
+                  </SalesTaxCodeRef>
+                </SalesReceiptLineRet>
+              </SalesReceiptRet>
+          </SalesReceiptAddRs>
+        </QBXMLMsgsRs>
+      </QBXML>
+
+    XML
+
+    assert_equal h, qbxml.from_qbxml(xml)
+  end
+
 end


### PR DESCRIPTION
Eliminates Ruby 2.6 warning:
```
BigDecimal.new is deprecated; use BigDecimal() method instead.
```
